### PR TITLE
Upgrade to 1.14, add new tags for use with custom resource packs

### DIFF
--- a/Plugin/pom.xml
+++ b/Plugin/pom.xml
@@ -64,7 +64,7 @@
 	</dependencies>
 
 	<build>
-        <finalName>ChestCommands</finalName>
+		<finalName>ChestCommands</finalName>
 		<resources>
 			<resource>
 				<directory>src/main/resources</directory>

--- a/Plugin/pom.xml
+++ b/Plugin/pom.xml
@@ -64,6 +64,7 @@
 	</dependencies>
 
 	<build>
+        <finalName>ChestCommands</finalName>
 		<resources>
 			<resource>
 				<directory>src/main/resources</directory>

--- a/Plugin/src/main/java/com/gmail/filoghost/chestcommands/ChestCommands.java
+++ b/Plugin/src/main/java/com/gmail/filoghost/chestcommands/ChestCommands.java
@@ -147,19 +147,6 @@ public class ChestCommands extends JavaPlugin {
 	@Override
 	public void onDisable() {
 		closeAllMenus();
-		HandlerList.unregisterAll(this);
-		Bukkit.getScheduler().cancelTasks(this);
-		getServer().getServicesManager().unregisterAll(this);
-		this.getServer().getMessenger().unregisterIncomingPluginChannel(this);
-		this.getServer().getMessenger().unregisterOutgoingPluginChannel(this);
-		instance = null;
-		settings = null;
-		lang = null;
-		fileNameToMenuMap = null;
-		commandsToMenuMap = null;
-		boundItems = null;
-		newVersion = null;
-		lastReloadErrors = 0;
 	}
 	
 	

--- a/Plugin/src/main/java/com/gmail/filoghost/chestcommands/ChestCommands.java
+++ b/Plugin/src/main/java/com/gmail/filoghost/chestcommands/ChestCommands.java
@@ -54,6 +54,7 @@ import com.gmail.filoghost.chestcommands.util.CaseInsensitiveMap;
 import com.gmail.filoghost.chestcommands.util.ErrorLogger;
 import com.gmail.filoghost.chestcommands.util.Utils;
 import com.gmail.filoghost.chestcommands.util.VersionUtils;
+import org.bukkit.event.HandlerList;
 
 public class ChestCommands extends JavaPlugin {
 	
@@ -146,6 +147,19 @@ public class ChestCommands extends JavaPlugin {
 	@Override
 	public void onDisable() {
 		closeAllMenus();
+        HandlerList.unregisterAll(this);
+        Bukkit.getScheduler().cancelTasks(this);
+        getServer().getServicesManager().unregisterAll(this);
+        this.getServer().getMessenger().unregisterIncomingPluginChannel(this);
+        this.getServer().getMessenger().unregisterOutgoingPluginChannel(this);
+        instance = null;
+        settings = null;
+        lang = null;
+        fileNameToMenuMap = null;
+        commandsToMenuMap = null;
+        boundItems = null;
+        newVersion = null;
+        lastReloadErrors = 0;
 	}
 	
 	

--- a/Plugin/src/main/java/com/gmail/filoghost/chestcommands/ChestCommands.java
+++ b/Plugin/src/main/java/com/gmail/filoghost/chestcommands/ChestCommands.java
@@ -147,19 +147,19 @@ public class ChestCommands extends JavaPlugin {
 	@Override
 	public void onDisable() {
 		closeAllMenus();
-        HandlerList.unregisterAll(this);
-        Bukkit.getScheduler().cancelTasks(this);
-        getServer().getServicesManager().unregisterAll(this);
-        this.getServer().getMessenger().unregisterIncomingPluginChannel(this);
-        this.getServer().getMessenger().unregisterOutgoingPluginChannel(this);
-        instance = null;
-        settings = null;
-        lang = null;
-        fileNameToMenuMap = null;
-        commandsToMenuMap = null;
-        boundItems = null;
-        newVersion = null;
-        lastReloadErrors = 0;
+		HandlerList.unregisterAll(this);
+		Bukkit.getScheduler().cancelTasks(this);
+		getServer().getServicesManager().unregisterAll(this);
+		this.getServer().getMessenger().unregisterIncomingPluginChannel(this);
+		this.getServer().getMessenger().unregisterOutgoingPluginChannel(this);
+		instance = null;
+		settings = null;
+		lang = null;
+		fileNameToMenuMap = null;
+		commandsToMenuMap = null;
+		boundItems = null;
+		newVersion = null;
+		lastReloadErrors = 0;
 	}
 	
 	

--- a/Plugin/src/main/java/com/gmail/filoghost/chestcommands/api/Icon.java
+++ b/Plugin/src/main/java/com/gmail/filoghost/chestcommands/api/Icon.java
@@ -37,13 +37,16 @@ import org.bukkit.inventory.meta.SkullMeta;
 import com.gmail.filoghost.chestcommands.ChestCommands;
 import com.gmail.filoghost.chestcommands.internal.Variable;
 import com.gmail.filoghost.chestcommands.util.Utils;
+import org.bukkit.inventory.meta.Damageable;
 
 public class Icon {
 
 	private Material material;
 	private int amount;
 	private short dataValue;
-	
+	private Integer damageValue = null;
+	private Integer customModelDataValue = null;
+    private boolean isUnbreakable = true;
 	private String nbtData;
 	private String name;
 	private List<String> lore;
@@ -83,9 +86,33 @@ public class Icon {
 		this.amount = amount;
 	}
 	
+    public void setIsUnbreakable(boolean unbreakable) {
+        this.isUnbreakable = unbreakable;
+    }
+    
+    public boolean isUnbreakable(){
+        return this.isUnbreakable;
+    }
+    
 	public int getAmount() {
 		return amount;
 	}
+
+    public int getDamageValue() {
+        return damageValue != null ? damageValue.intValue() : 0;
+    }
+
+    public void setDamageValue(int damageValue) {
+        this.damageValue = damageValue;
+    }
+
+    public int getCustomModelDataValue() {
+        return customModelDataValue != null ? customModelDataValue.intValue() : 0;
+    }
+
+    public void setCustomModelDataValue(Integer customModelDataValue) {
+        this.customModelDataValue = customModelDataValue;
+    }
 	
 	public void setDataValue(short dataValue) {
 		if (dataValue < 0) dataValue = 0;
@@ -311,14 +338,15 @@ public class Icon {
 		
 		// Then apply data from config nodes, overwriting NBT data if there are confliting values
 		ItemMeta itemMeta = itemStack.getItemMeta();
-		
-		if (hasName()) {
+
+        if (hasName()) {
 			itemMeta.setDisplayName(calculateName(pov));
 		}
 		if (hasLore()) {
 			itemMeta.setLore(calculateLore(pov));
 		}
 		
+        
 		if (color != null && itemMeta instanceof LeatherArmorMeta) {
 			((LeatherArmorMeta) itemMeta).setColor(color);
 		}
@@ -326,7 +354,17 @@ public class Icon {
 		if (skullOwner != null && itemMeta instanceof SkullMeta) {
 			((SkullMeta) itemMeta).setOwner(skullOwner);
 		}
-		
+        
+        if (this.damageValue != null && itemMeta instanceof Damageable) {
+            ((Damageable)itemMeta).setDamage(this.damageValue);
+        }
+        
+        itemMeta.setUnbreakable(this.isUnbreakable); // If true, damaged = 0, Unbreaking = 1
+        
+        if (this.customModelDataValue != null) {
+            itemMeta.setCustomModelData(this.customModelDataValue);
+        }
+        
 		itemStack.setItemMeta(itemMeta);
 		
 		if (enchantments.size() > 0) {

--- a/Plugin/src/main/java/com/gmail/filoghost/chestcommands/api/Icon.java
+++ b/Plugin/src/main/java/com/gmail/filoghost/chestcommands/api/Icon.java
@@ -46,7 +46,7 @@ public class Icon {
 	private short dataValue;
 	private Integer damageValue = null;
 	private Integer customModelDataValue = null;
-    private boolean isUnbreakable = true;
+	private boolean isUnbreakable = true;
 	private String nbtData;
 	private String name;
 	private List<String> lore;
@@ -86,33 +86,33 @@ public class Icon {
 		this.amount = amount;
 	}
 	
-    public void setIsUnbreakable(boolean unbreakable) {
-        this.isUnbreakable = unbreakable;
-    }
-    
-    public boolean isUnbreakable(){
-        return this.isUnbreakable;
-    }
-    
+	public void setIsUnbreakable(boolean unbreakable) {
+		this.isUnbreakable = unbreakable;
+	}
+	
+	public boolean isUnbreakable(){
+		return this.isUnbreakable;
+	}
+	
 	public int getAmount() {
 		return amount;
 	}
 
-    public int getDamageValue() {
-        return damageValue != null ? damageValue.intValue() : 0;
-    }
+	public int getDamageValue() {
+		return damageValue != null ? damageValue.intValue() : 0;
+	}
 
-    public void setDamageValue(int damageValue) {
-        this.damageValue = damageValue;
-    }
+	public void setDamageValue(int damageValue) {
+		this.damageValue = damageValue;
+	}
 
-    public int getCustomModelDataValue() {
-        return customModelDataValue != null ? customModelDataValue.intValue() : 0;
-    }
+	public int getCustomModelDataValue() {
+		return customModelDataValue != null ? customModelDataValue.intValue() : 0;
+	}
 
-    public void setCustomModelDataValue(Integer customModelDataValue) {
-        this.customModelDataValue = customModelDataValue;
-    }
+	public void setCustomModelDataValue(Integer customModelDataValue) {
+		this.customModelDataValue = customModelDataValue;
+	}
 	
 	public void setDataValue(short dataValue) {
 		if (dataValue < 0) dataValue = 0;
@@ -339,14 +339,14 @@ public class Icon {
 		// Then apply data from config nodes, overwriting NBT data if there are confliting values
 		ItemMeta itemMeta = itemStack.getItemMeta();
 
-        if (hasName()) {
+		if (hasName()) {
 			itemMeta.setDisplayName(calculateName(pov));
 		}
 		if (hasLore()) {
 			itemMeta.setLore(calculateLore(pov));
 		}
 		
-        
+		
 		if (color != null && itemMeta instanceof LeatherArmorMeta) {
 			((LeatherArmorMeta) itemMeta).setColor(color);
 		}
@@ -354,17 +354,17 @@ public class Icon {
 		if (skullOwner != null && itemMeta instanceof SkullMeta) {
 			((SkullMeta) itemMeta).setOwner(skullOwner);
 		}
-        
-        if (this.damageValue != null && itemMeta instanceof Damageable) {
-            ((Damageable)itemMeta).setDamage(this.damageValue);
-        }
-        
-        itemMeta.setUnbreakable(this.isUnbreakable); // If true, damaged = 0, Unbreaking = 1
-        
-        if (this.customModelDataValue != null) {
-            itemMeta.setCustomModelData(this.customModelDataValue);
-        }
-        
+		
+		if (this.damageValue != null && itemMeta instanceof Damageable) {
+			((Damageable)itemMeta).setDamage(this.damageValue);
+		}
+		
+		itemMeta.setUnbreakable(this.isUnbreakable); // If true, damaged = 0, Unbreaking = 1
+		
+		if (this.customModelDataValue != null) {
+			itemMeta.setCustomModelData(this.customModelDataValue);
+		}
+		
 		itemStack.setItemMeta(itemMeta);
 		
 		if (enchantments.size() > 0) {

--- a/Plugin/src/main/java/com/gmail/filoghost/chestcommands/internal/ExtendedIconMenu.java
+++ b/Plugin/src/main/java/com/gmail/filoghost/chestcommands/internal/ExtendedIconMenu.java
@@ -79,7 +79,7 @@ public class ExtendedIconMenu extends IconMenu {
 				}
 			}
 			
-            InventoryHolder menuInventoryHolder = new MenuInventoryHolder(this);
+			InventoryHolder menuInventoryHolder = new MenuInventoryHolder(this);
 			Inventory inventory = Bukkit.createInventory(menuInventoryHolder, icons.length, title);
 	
 			for (int i = 0; i < icons.length; i++) {

--- a/Plugin/src/main/java/com/gmail/filoghost/chestcommands/internal/ExtendedIconMenu.java
+++ b/Plugin/src/main/java/com/gmail/filoghost/chestcommands/internal/ExtendedIconMenu.java
@@ -30,6 +30,7 @@ import com.gmail.filoghost.chestcommands.api.IconMenu;
 import com.gmail.filoghost.chestcommands.internal.icon.ExtendedIcon;
 import com.gmail.filoghost.chestcommands.internal.icon.IconCommand;
 import com.gmail.filoghost.chestcommands.nms.AttributeRemover;
+import org.bukkit.inventory.InventoryHolder;
 
 public class ExtendedIconMenu extends IconMenu {
 	
@@ -78,7 +79,8 @@ public class ExtendedIconMenu extends IconMenu {
 				}
 			}
 			
-			Inventory inventory = Bukkit.createInventory(new MenuInventoryHolder(this), icons.length, title);
+            InventoryHolder menuInventoryHolder = new MenuInventoryHolder(this);
+			Inventory inventory = Bukkit.createInventory(menuInventoryHolder, icons.length, title);
 	
 			for (int i = 0; i < icons.length; i++) {
 				if (icons[i] != null) {

--- a/Plugin/src/main/java/com/gmail/filoghost/chestcommands/serializer/IconSerializer.java
+++ b/Plugin/src/main/java/com/gmail/filoghost/chestcommands/serializer/IconSerializer.java
@@ -43,11 +43,11 @@ public class IconSerializer {
 				DURABILITY = "DURABILITY",
 				DAMAGE = "DAMAGE",
 				CUSTOM_MODEL_DATA = "CUSTOM-MODEL-DATA",
-            
+			
 				UNBREAKABLE = "UNBREAKABLE", // These correspond to the Unbreakable NBT tag on item stacks.
 				UNBREAKABLE_UNBREAKING = "UNBREAKING",
 				UNBREAKABLE_DAMAGED = "DAMAGED", 
-            
+			
 				NBT_DATA = "NBT-DATA",
 				NAME = "NAME",
 				LORE = "LORE",
@@ -119,18 +119,19 @@ public class IconSerializer {
 		} else if (section.isSet(Nodes.DATA_VALUE)) { // Alias
 			icon.setDataValue((short) section.getInt(Nodes.DATA_VALUE));
 		}
-        
-        boolean isUnbreakable = section.getBoolean(Nodes.UNBREAKABLE, section.getBoolean(Nodes.UNBREAKABLE_DAMAGED,section.getBoolean(Nodes.UNBREAKABLE_UNBREAKING, true)));
-		icon.setIsUnbreakable(isUnbreakable);
-        
-        if (section.isSet(Nodes.DAMAGE)) {
+		
+		String isUnbreakableStr = section.getString(Nodes.UNBREAKABLE, section.getString(Nodes.UNBREAKABLE_DAMAGED,section.getString(Nodes.UNBREAKABLE_UNBREAKING, null)));
+		boolean isUnbreakable = isUnbreakableStr == null || "1".equals(isUnbreakableStr) || "true".equalsIgnoreCase(isUnbreakableStr);
+        icon.setIsUnbreakable(isUnbreakable);
+		
+		if (section.isSet(Nodes.DAMAGE)) {
 			icon.setDamageValue(section.getInt(Nodes.DAMAGE));
 		}
-        
+		
 		if (section.isSet(Nodes.CUSTOM_MODEL_DATA)) {
 			icon.setCustomModelDataValue(section.getInt(Nodes.CUSTOM_MODEL_DATA));
 		}
-        
+		
 		if (section.isSet(Nodes.NBT_DATA)) {
 			String nbtData = section.getString(Nodes.NBT_DATA);
 			try {

--- a/Plugin/src/main/java/com/gmail/filoghost/chestcommands/serializer/IconSerializer.java
+++ b/Plugin/src/main/java/com/gmail/filoghost/chestcommands/serializer/IconSerializer.java
@@ -41,6 +41,13 @@ public class IconSerializer {
 				AMOUNT = "AMOUNT",
 				DATA_VALUE = "DATA-VALUE",
 				DURABILITY = "DURABILITY",
+				DAMAGE = "DAMAGE",
+				CUSTOM_MODEL_DATA = "CUSTOM-MODEL-DATA",
+            
+				UNBREAKABLE = "UNBREAKABLE", // These correspond to the Unbreakable NBT tag on item stacks.
+				UNBREAKABLE_UNBREAKING = "UNBREAKING",
+				UNBREAKABLE_DAMAGED = "DAMAGED", 
+            
 				NBT_DATA = "NBT-DATA",
 				NAME = "NAME",
 				LORE = "LORE",
@@ -112,7 +119,18 @@ public class IconSerializer {
 		} else if (section.isSet(Nodes.DATA_VALUE)) { // Alias
 			icon.setDataValue((short) section.getInt(Nodes.DATA_VALUE));
 		}
-		
+        
+        boolean isUnbreakable = section.getBoolean(Nodes.UNBREAKABLE, section.getBoolean(Nodes.UNBREAKABLE_DAMAGED,section.getBoolean(Nodes.UNBREAKABLE_UNBREAKING, true)));
+		icon.setIsUnbreakable(isUnbreakable);
+        
+        if (section.isSet(Nodes.DAMAGE)) {
+			icon.setDamageValue(section.getInt(Nodes.DAMAGE));
+		}
+        
+		if (section.isSet(Nodes.CUSTOM_MODEL_DATA)) {
+			icon.setCustomModelDataValue(section.getInt(Nodes.CUSTOM_MODEL_DATA));
+		}
+        
 		if (section.isSet(Nodes.NBT_DATA)) {
 			String nbtData = section.getString(Nodes.NBT_DATA);
 			try {

--- a/Plugin/src/main/java/com/gmail/filoghost/chestcommands/serializer/IconSerializer.java
+++ b/Plugin/src/main/java/com/gmail/filoghost/chestcommands/serializer/IconSerializer.java
@@ -122,7 +122,7 @@ public class IconSerializer {
 		
 		String isUnbreakableStr = section.getString(Nodes.UNBREAKABLE, section.getString(Nodes.UNBREAKABLE_DAMAGED,section.getString(Nodes.UNBREAKABLE_UNBREAKING, null)));
 		boolean isUnbreakable = isUnbreakableStr == null || "1".equals(isUnbreakableStr) || "true".equalsIgnoreCase(isUnbreakableStr);
-        icon.setIsUnbreakable(isUnbreakable);
+		icon.setIsUnbreakable(isUnbreakable);
 		
 		if (section.isSet(Nodes.DAMAGE)) {
 			icon.setDamageValue(section.getInt(Nodes.DAMAGE));

--- a/Plugin/src/main/resources/plugin.yml
+++ b/Plugin/src/main/resources/plugin.yml
@@ -1,7 +1,7 @@
 name: ChestCommands
 main: com.gmail.filoghost.chestcommands.ChestCommands
 version: ${project.version}
-api-version: 1.13
+api-version: 1.14
 
 softdepend: [Vault, BarAPI]
 

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
 		<maven.compiler.source>1.6</maven.compiler.source>
 		<maven.compiler.target>1.6</maven.compiler.target>
 		<maven.test.skip>true</maven.test.skip>
-		<spigot-api.version>1.8-R0.1-SNAPSHOT</spigot-api.version>
+		<spigot-api.version>1.14-R0.1-SNAPSHOT</spigot-api.version>
 	</properties>
 
 	<modules>


### PR DESCRIPTION
- Upgrade to 1.14
- Add new tags for custom resource packs. (New additions will ultimately affect: damaged, damage, and custom_model_data when viewed through predicates for resource packs. To affect each, use DAMAGE, DAMAGED/UNBREAKABLE/UNBREAKING, CUSTOM-MODEL-DATA. 
- Better data clean-up when plugin unloads.
![image](https://user-images.githubusercontent.com/1046026/56923265-f9bf5400-6a7e-11e9-981a-9e772c02b013.png)
![image](https://user-images.githubusercontent.com/1046026/56923308-16f42280-6a7f-11e9-913d-5bb7b9fdc768.png)
