### PR TITLE
Add DAMAGE, DAMAGED, UNBREAKABLE, and CUSTOM_MODEL_DATA to config opt…

### DIFF
--- a/Plugin/src/main/java/com/gmail/filoghost/chestcommands/api/Icon.java
+++ b/Plugin/src/main/java/com/gmail/filoghost/chestcommands/api/Icon.java
@@ -16,6 +16,7 @@ package com.gmail.filoghost.chestcommands.api;
 
 import com.gmail.filoghost.chestcommands.ChestCommands;
 import com.gmail.filoghost.chestcommands.internal.VariableManager;
+import com.gmail.filoghost.chestcommands.util.BukkitUtils;
 import com.gmail.filoghost.chestcommands.util.Utils;
 import org.bukkit.*;
 import org.bukkit.block.banner.Pattern;
@@ -39,6 +40,9 @@ public class Icon {
 	private Material material;
 	private int amount;
 	private short dataValue;
+	private Integer damageValue = null;
+	private Integer customModelDataValue = null;
+	private boolean isUnbreakable = true;
 
 	private String nbtData;
 	private String name;
@@ -60,7 +64,7 @@ public class Icon {
 	public Icon() {
 		enchantments = new HashMap<Enchantment, Integer>();
 		closeOnClick = true;
-		amount = 1;        
+		amount = 1;		
 	}
 
 	public boolean hasVariables() {
@@ -75,7 +79,30 @@ public class Icon {
 	public Material getMaterial() {
 		return material;
 	}
+	
+	public void setIsUnbreakable(boolean unbreakable) {
+		this.isUnbreakable = unbreakable;
+	}
 
+	public boolean isUnbreakable(){
+		return this.isUnbreakable;
+	}
+	public int getDamageValue() {
+		return damageValue != null ? damageValue.intValue() : 0;
+	}
+
+	public void setDamageValue(int damageValue) {
+		this.damageValue = damageValue;
+	}
+
+	public int getCustomModelDataValue() {
+		return customModelDataValue != null ? customModelDataValue.intValue() : 0;
+	}
+
+	public void setCustomModelDataValue(Integer customModelDataValue) {
+		this.customModelDataValue = customModelDataValue;
+	}
+	
 	public void setAmount(int amount) {
 		if (amount < 1) amount = 1;
 		else if (amount > 127) amount = 127;
@@ -323,9 +350,19 @@ public class Icon {
 				((BannerMeta) itemMeta).setPatterns(bannerPatterns);
 			}
 		}
+		
+		if (this.damageValue != null) {
+			BukkitUtils.setDamageValueForItemMeta(itemMeta, this.damageValue);
+		}
+		
+		BukkitUtils.setUnbreakableValueForItemMeta(itemMeta, this.isUnbreakable);
 
+		if (this.customModelDataValue != null) {
+			BukkitUtils.setCustomModelDataForItemMeta(itemMeta, this.customModelDataValue);
+		}
+		
 		itemStack.setItemMeta(itemMeta);
-
+		
 		if (enchantments.size() > 0) {
 			for (Entry<Enchantment, Integer> entry : enchantments.entrySet()) {
 				itemStack.addUnsafeEnchantment(entry.getKey(), entry.getValue());

--- a/Plugin/src/main/java/com/gmail/filoghost/chestcommands/util/BukkitUtils.java
+++ b/Plugin/src/main/java/com/gmail/filoghost/chestcommands/util/BukkitUtils.java
@@ -9,6 +9,9 @@ import org.bukkit.plugin.Plugin;
 import java.lang.reflect.Method;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import org.bukkit.inventory.meta.ItemMeta;
 
 public final class BukkitUtils {
 
@@ -27,6 +30,45 @@ public final class BukkitUtils {
 	private BukkitUtils() {
 	}
 
+	// itemMeta.setCustomModelData(this.customModelDataValue);
+	public static void setCustomModelDataForItemMeta(ItemMeta itemMeta, int customModelDataValue) {
+		 try {
+			Method declaredMethod = ItemMeta.class.getDeclaredMethod("setCustomModelData", Integer.class);
+			declaredMethod.invoke(itemMeta, customModelDataValue);
+		} catch (Exception ex) {
+			Logger.getLogger(BukkitUtils.class.getName()).log(Level.SEVERE, null, ex);
+		}
+	}
+ 
+	// itemMeta.setUnbreakable(this.isUnbreakable); // If true, damaged = 0, Unbreaking = 1
+	public static void setUnbreakableValueForItemMeta(ItemMeta itemMeta, boolean unbreakable) {
+		try {
+			Method declaredMethod = ItemMeta.class.getDeclaredMethod("setUnbreakable", boolean.class);
+			declaredMethod.invoke(itemMeta, unbreakable);
+		} catch (Exception ex) {
+			Logger.getLogger(BukkitUtils.class.getName()).log(Level.SEVERE, null, ex);
+		}
+	}
+
+	
+	/**
+	 *  if (damageableInterface.isAssignableFrom(itemMeta.getClass())){
+	 *	  ((Damageable)itemMeta).setDamage(this.damageValue);
+	 *  }
+	 * @param itemMeta
+	 * @param damageVal 
+	 */
+	  
+	public static void setDamageValueForItemMeta(ItemMeta itemMeta, int damageVal){
+		try {
+			Class<?> damageableInterface = Class.forName("org.bukkit.inventory.meta.Damageable");
+			Method declaredMethod = damageableInterface.getDeclaredMethod("setDamage", int.class);
+			declaredMethod.invoke(itemMeta, damageVal);
+		} catch (Exception ex) {
+			Logger.getLogger(BukkitUtils.class.getName()).log(Level.SEVERE, null, ex);
+		}
+	}
+	
 	public static Collection<? extends Player> getOnlinePlayers() {
 		try {
 			if (LEGACY_GET_ONLINE_PLAYERS == null) {


### PR DESCRIPTION
Add new tags for custom resource packs. (New additions will ultimately affect: damaged, damage, and custom_model_data when viewed through predicates for resource packs. To affect each, use DAMAGE, DAMAGED/UNBREAKABLE/UNBREAKING, CUSTOM-MODEL-DATA.
Better data clean-up when plugin unloads.

![image](https://user-images.githubusercontent.com/1046026/57428565-cea2d600-71dd-11e9-83da-8713c91b98df.png)
![image](https://user-images.githubusercontent.com/1046026/57428575-d9f60180-71dd-11e9-95af-194be88ebcc1.png)
