### PR TITLE
Add support for having REQUIRED_ITEM as list

### DIFF
--- a/Plugin/src/main/java/com/gmail/filoghost/chestcommands/internal/icon/ExtendedIcon.java
+++ b/Plugin/src/main/java/com/gmail/filoghost/chestcommands/internal/icon/ExtendedIcon.java
@@ -40,7 +40,7 @@ public class ExtendedIcon extends Icon {
 
 	private double moneyPrice;
 	private int expLevelsPrice;
-	private RequiredItem requiredItem;
+	private List<RequiredItem> requiredItems;
 
 	public ExtendedIcon() {
 		super();
@@ -126,12 +126,12 @@ public class ExtendedIcon extends Icon {
 		this.expLevelsPrice = expLevelsPrice;
 	}
 
-	public RequiredItem getRequiredItem() {
-		return requiredItem;
+	public List<RequiredItem> getRequiredItems() {
+		return requiredItems;
 	}
 
-	public void setRequiredItem(RequiredItem requiredItem) {
-		this.requiredItem = requiredItem;
+	public void setRequiredItems(List<RequiredItem> requiredItems) {
+		this.requiredItems = requiredItems;
 	}
 
 	public String calculateName(Player pov) {
@@ -176,16 +176,16 @@ public class ExtendedIcon extends Icon {
 			}
 		}
 
-		if (requiredItem != null) {
-
-			if (!requiredItem.hasItem(player)) {
-				player.sendMessage(ChestCommands.getLang().no_required_item
-						.replace("{material}", MaterialsRegistry.formatMaterial(requiredItem.getMaterial()))
-						.replace("{id}", Integer.toString(requiredItem.getMaterial().getId()))
-						.replace("{amount}", Integer.toString(requiredItem.getAmount()))
-						.replace("{datavalue}", requiredItem.hasRestrictiveDataValue() ? Short.toString(requiredItem.getDataValue()) : ChestCommands.getLang().any)
-				);
-				return closeOnClick;
+		if (requiredItems != null) {
+			for (RequiredItem item : requiredItems) {
+				if (!item.hasItem(player)) {
+					player.sendMessage(ChestCommands.getLang().no_required_item
+							.replace("{material}", MaterialsRegistry.formatMaterial(item.getMaterial()))
+							.replace("{amount}", Integer.toString(item.getAmount()))
+							.replace("{datavalue}", item.hasRestrictiveDataValue() ? Short.toString(item.getDataValue()) : ChestCommands.getLang().any)
+					);
+					return closeOnClick;
+				}
 			}
 		}
 
@@ -205,8 +205,10 @@ public class ExtendedIcon extends Icon {
 			player.setLevel(player.getLevel() - expLevelsPrice);
 		}
 
-		if (requiredItem != null) {
-			requiredItem.takeItem(player);
+		if (requiredItems != null) {
+			for (RequiredItem item : requiredItems) {
+				item.takeItem(player);
+			}
 		}
 
 		if (changedVariables) {

--- a/Plugin/src/main/java/com/gmail/filoghost/chestcommands/serializer/IconSerializer.java
+++ b/Plugin/src/main/java/com/gmail/filoghost/chestcommands/serializer/IconSerializer.java
@@ -24,8 +24,11 @@ import com.gmail.filoghost.chestcommands.internal.icon.IconCommand;
 import com.gmail.filoghost.chestcommands.util.*;
 import com.gmail.filoghost.chestcommands.util.nbt.parser.MojangsonParseException;
 import com.gmail.filoghost.chestcommands.util.nbt.parser.MojangsonParser;
+import org.bukkit.Material;
 import org.bukkit.configuration.ConfigurationSection;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 public class IconSerializer {
@@ -198,16 +201,27 @@ public class IconSerializer {
 		}
 
 		if (section.isSet(Nodes.REQUIRED_ITEM)) {
-			try {
-				ItemStackReader itemReader = new ItemStackReader(section.getString(Nodes.REQUIRED_ITEM), true);
-				RequiredItem requiredItem = new RequiredItem(itemReader.getMaterial(), itemReader.getAmount());
-				if (itemReader.hasExplicitDataValue()) {
-					requiredItem.setRestrictiveDataValue(itemReader.getDataValue());
-				}
-				icon.setRequiredItem(requiredItem);
-			} catch (FormatException e) {
-				errorLogger.addError("The icon \"" + iconName + "\" in the menu \"" + menuFileName + "\" has an invalid REQUIRED-ITEM: " + e.getMessage());
+			List<String> requiredItemsStrings;
+			if (section.isList(Nodes.REQUIRED_ITEM)) {
+				requiredItemsStrings = section.getStringList(Nodes.REQUIRED_ITEM);
+			} else {
+				requiredItemsStrings = Collections.singletonList(section.getString(Nodes.REQUIRED_ITEM));
 			}
+
+			List<RequiredItem> requiredItems = new ArrayList<RequiredItem>();
+			for (String requiredItemText : requiredItemsStrings) {
+				try {
+					ItemStackReader itemReader = new ItemStackReader(requiredItemText, true);
+					RequiredItem requiredItem = new RequiredItem(itemReader.getMaterial(), itemReader.getAmount());
+					if (itemReader.hasExplicitDataValue()) {
+						requiredItem.setRestrictiveDataValue(itemReader.getDataValue());
+					}
+					requiredItems.add(requiredItem);
+				} catch (FormatException e) {
+					errorLogger.addError("The icon \"" + iconName + "\" in the menu \"" + menuFileName + "\" has an invalid REQUIRED-ITEM: " + e.getMessage());
+				}
+			}
+			icon.setRequiredItems(requiredItems);
 		}
 
 		return icon;


### PR DESCRIPTION
Config example:
  REQUIRED-ITEM:
    - coal, 128
    - cobblestone, 128

The old style is still supported for only one item:
  REQUIRED-ITEM: coal, 128


In addition to this, I also removed `{id}` message replacement to be compatible with Minecraft 1.14.