### PR TITLE
Added Multiple permissions.

### DIFF
--- a/plugin/src/main/java/me/filoghost/chestcommands/attribute/ClickPermissionMessagesAttribute.java
+++ b/plugin/src/main/java/me/filoghost/chestcommands/attribute/ClickPermissionMessagesAttribute.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) filoghost and contributors
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+package me.filoghost.chestcommands.attribute;
+
+import me.filoghost.chestcommands.icon.InternalConfigurableIcon;
+
+import java.util.List;
+
+public class ClickPermissionMessagesAttribute implements IconAttribute {
+
+    private final List<String> messages;
+
+    public ClickPermissionMessagesAttribute(List<String> messages, AttributeErrorHandler errorHandler) {
+        this.messages = messages;
+    }
+
+    @Override
+    public void apply(InternalConfigurableIcon icon) {
+        icon.setNoclickPermissionMessages(this.messages);
+    }
+
+}

--- a/plugin/src/main/java/me/filoghost/chestcommands/attribute/ClickPermissionsAttribute.java
+++ b/plugin/src/main/java/me/filoghost/chestcommands/attribute/ClickPermissionsAttribute.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) filoghost and contributors
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+package me.filoghost.chestcommands.attribute;
+
+import me.filoghost.chestcommands.icon.IconPermissions;
+import me.filoghost.chestcommands.icon.InternalConfigurableIcon;
+
+import java.util.List;
+
+public class ClickPermissionsAttribute implements IconAttribute{
+
+    private final IconPermissions permissions;
+
+    public ClickPermissionsAttribute(List<String> permissions, AttributeErrorHandler errorHandler){
+        this.permissions = new IconPermissions(permissions);
+    }
+
+    @Override
+    public void apply(InternalConfigurableIcon icon) {
+        icon.setClickPermissions(this.permissions);
+    }
+}

--- a/plugin/src/main/java/me/filoghost/chestcommands/icon/IconPermissions.java
+++ b/plugin/src/main/java/me/filoghost/chestcommands/icon/IconPermissions.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) filoghost and contributors
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+package me.filoghost.chestcommands.icon;
+
+import me.filoghost.chestcommands.config.Lang;
+import me.filoghost.chestcommands.placeholder.PlaceholderString;
+import org.bukkit.entity.Player;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class IconPermissions {
+
+    private List<IconPermission> permissions;
+
+    public IconPermissions(List<String> permissions) {
+        if (permissions != null && permissions.size() > 0) {
+            this.permissions = new ArrayList<>();
+            for (String perm : permissions) {
+                this.permissions.add(new IconPermission(perm));
+            }
+        }
+    }
+
+    public boolean checkAndSendMessages(Player player, List<PlaceholderString> messages) {
+        if (isEmpty()) {
+            return true;
+        }
+
+        boolean result = true;
+        int messagesiz = messages != null ? messages.size() : 0;
+
+        for (int i = 0; i < permissions.size(); i++) {
+            IconPermission perm = permissions.get(i);
+            if (!IconPermission.hasPermission(player, perm)) {
+                result = false;
+                if (messagesiz >= i + 1) {
+                    PlaceholderString pstring = messages.get(i);
+                    if (pstring != null) {
+                        player.sendMessage(pstring.getValue(player));
+                    } else {
+                        player.sendMessage(Lang.default_no_icon_permission);
+                    }
+                }
+            }
+        }
+        return result;
+    }
+
+    public boolean isEmpty() {
+        return this.permissions == null || this.permissions.isEmpty();
+    }
+
+}

--- a/plugin/src/main/java/me/filoghost/chestcommands/icon/InternalConfigurableIcon.java
+++ b/plugin/src/main/java/me/filoghost/chestcommands/icon/InternalConfigurableIcon.java
@@ -15,6 +15,7 @@ import me.filoghost.chestcommands.icon.requirement.RequiredMoney;
 import me.filoghost.chestcommands.icon.requirement.Requirement;
 import me.filoghost.chestcommands.icon.requirement.item.RequiredItem;
 import me.filoghost.chestcommands.icon.requirement.item.RequiredItems;
+import me.filoghost.chestcommands.placeholder.PlaceholderString;
 import me.filoghost.fcommons.Preconditions;
 import me.filoghost.fcommons.collection.CollectionUtils;
 import org.bukkit.Material;
@@ -24,13 +25,17 @@ import org.bukkit.inventory.meta.ItemMeta;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.ArrayList;
 import java.util.List;
 
 public class InternalConfigurableIcon extends BaseConfigurableIcon implements RefreshableIcon {
 
     private IconPermission viewPermission;
     private IconPermission clickPermission;
-    private String noClickPermissionMessage;
+    private PlaceholderString noClickPermissionMessage;
+
+    private IconPermissions clickPermissions;
+    private List<PlaceholderString> permissionMessages;
 
     private RequiredMoney requiredMoney;
     private RequiredExpLevel requiredExpLevel;
@@ -58,9 +63,22 @@ public class InternalConfigurableIcon extends BaseConfigurableIcon implements Re
     }
     
     public void setNoClickPermissionMessage(String noClickPermissionMessage) {
-        this.noClickPermissionMessage = noClickPermissionMessage;
+        this.noClickPermissionMessage = PlaceholderString.of(noClickPermissionMessage);
     }
-        
+
+    public void setClickPermissions(IconPermissions clickPermissions) {
+        this.clickPermissions = clickPermissions;
+    }
+
+    public void setNoclickPermissionMessages(List<String> messages) {
+        if (messages != null && !messages.isEmpty()) {
+            this.permissionMessages = new ArrayList<>(messages.size());
+            for (String message : messages) {
+                this.permissionMessages.add(PlaceholderString.of(message));
+            }
+        }
+    }
+
     public void setViewPermission(String viewPermission) {
         this.viewPermission = new IconPermission(viewPermission);
     }
@@ -129,11 +147,17 @@ public class InternalConfigurableIcon extends BaseConfigurableIcon implements Re
 
         if (!IconPermission.hasPermission(player, clickPermission)) {
             if (noClickPermissionMessage != null) {
-                player.sendMessage(noClickPermissionMessage);
+                player.sendMessage(noClickPermissionMessage.getValue(player));
             } else {
                 player.sendMessage(Lang.default_no_icon_permission);
             }
             return clickResult;
+        }
+
+        if (clickPermissions !=null) {
+            if (!clickPermissions.checkAndSendMessages(player, permissionMessages)) {
+                return clickResult;
+            }
         }
 
         // Check all the requirements

--- a/plugin/src/main/java/me/filoghost/chestcommands/parsing/icon/AttributeType.java
+++ b/plugin/src/main/java/me/filoghost/chestcommands/parsing/icon/AttributeType.java
@@ -12,6 +12,8 @@ import me.filoghost.chestcommands.attribute.BannerColorAttribute;
 import me.filoghost.chestcommands.attribute.BannerPatternsAttribute;
 import me.filoghost.chestcommands.attribute.ClickPermissionAttribute;
 import me.filoghost.chestcommands.attribute.ClickPermissionMessageAttribute;
+import me.filoghost.chestcommands.attribute.ClickPermissionsAttribute;
+import me.filoghost.chestcommands.attribute.ClickPermissionMessagesAttribute;
 import me.filoghost.chestcommands.attribute.DurabilityAttribute;
 import me.filoghost.chestcommands.attribute.EnchantmentsAttribute;
 import me.filoghost.chestcommands.attribute.ExpLevelsAttribute;
@@ -53,6 +55,8 @@ public enum AttributeType {
     EXP_LEVELS("LEVELS", ConfigValueType.INTEGER, ExpLevelsAttribute::new),
     CLICK_PERMISSION("PERMISSION", ConfigValueType.STRING, ClickPermissionAttribute::new),
     CLICK_PERMISSION_MESSAGE("PERMISSION-MESSAGE", ConfigValueType.STRING, ClickPermissionMessageAttribute::new),
+    CLICK_PERMISSIONS("PERMISSIONS", ConfigValueType.STRING_LIST, ClickPermissionsAttribute::new),
+    CLICK_PERMISSION_MESSAGES("PERMISSION-MESSAGES", ConfigValueType.STRING_LIST, ClickPermissionMessagesAttribute::new),
     VIEW_PERMISSION("VIEW-PERMISSION", ConfigValueType.STRING, ViewPermissionAttribute::new),
     KEEP_OPEN("KEEP-OPEN", ConfigValueType.BOOLEAN, KeepOpenAttribute::new),
     ACTIONS("ACTIONS", ConfigValueType.STRING_LIST, ActionsAttribute::new),


### PR DESCRIPTION
Sometimes we need to judge multiple permissions, we can write nodes like this:

```
upgrad-to-vip2:
  MATERIAL: diamond
  POSITION-X: 2
  POSITION-Y: 1
  NAME: '&eVIP2'
  LORE:
    - 'Upgrade from vip1 to vip2.'
    - '1. You can ...'
    - '2. You can ...'
  ACTIONS:
    - 'console: lp user {player} promote track1'
    - 'broadcast: Congratulations to {player} for upgrading to VIP2.'
  PERMISSIONS:
    - 'myserver.vip1'     # Must have vip1 to upgrade vip2
    - '-myserver.vip2'    # If it is already vip2, it cannot be upgraded.
  PERMISSION-MESSAGES:
    - 'Hey, {player}, you must be vip1 to upgrade to vip2.'
    - 'Hey, {player}, you are already vip2, please do not upgrade repeatedly.'

```